### PR TITLE
fix: fix otel components shutdown within runtime context

### DIFF
--- a/moat/src/main.rs
+++ b/moat/src/main.rs
@@ -41,9 +41,10 @@ fn main() {
 
     tracing::info!(?config, "Start Moat");
 
-    if let Err(e) = Moat::run(config, runtime) {
+    if let Err(e) = Moat::run(config, &runtime) {
         tracing::error!(?e, "Failed to run Moat");
     }
 
     drop(guards);
+    drop(runtime);
 }

--- a/moat/src/telemetry/logging.rs
+++ b/moat/src/telemetry/logging.rs
@@ -66,12 +66,15 @@ pub fn init(config: &TelemetryConfig, peer: &Peer, attributes: &[KeyValue]) -> R
         .with(otel_layer)
         .init();
 
+    let handle = tokio::runtime::Handle::current();
     Ok(Box::new(scopeguard::guard((), move |_| {
-        provider
-            .shutdown()
-            .inspect_err(|e| {
-                tracing::error!(?e, "Failed to shutdown OpenTelemetry Tracer Provider");
-            })
-            .ok();
+        handle.block_on(async {
+            provider
+                .shutdown()
+                .inspect_err(|e| {
+                    tracing::error!(?e, "Failed to shutdown OpenTelemetry Tracer Provider");
+                })
+                .ok();
+        })
     })))
 }

--- a/moat/src/telemetry/meter.rs
+++ b/moat/src/telemetry/meter.rs
@@ -44,12 +44,15 @@ pub fn init(config: &TelemetryConfig, _: &Peer, attributes: &[KeyValue]) -> Resu
 
     opentelemetry::global::set_meter_provider(provider.clone());
 
+    let handle = tokio::runtime::Handle::current();
     Ok(Box::new(scopeguard::guard((), move |_| {
-        provider
-            .shutdown()
-            .inspect_err(|e| {
-                tracing::error!(?e, "Failed to shutdown OpenTelemetry Meter Provider");
-            })
-            .ok();
+        handle.block_on(async {
+            provider
+                .shutdown()
+                .inspect_err(|e| {
+                    tracing::error!(?e, "Failed to shutdown OpenTelemetry Meter Provider");
+                })
+                .ok();
+        })
     })))
 }

--- a/moat/src/telemetry/mod.rs
+++ b/moat/src/telemetry/mod.rs
@@ -15,12 +15,14 @@
 mod logging;
 mod meter;
 
+use std::collections::VecDeque;
+
 use opentelemetry::KeyValue;
 
 use crate::{config::MoatConfig, error::Result};
 
 pub fn init(config: &MoatConfig) -> Result<Box<dyn Send + Sync + 'static>> {
-    let mut guards = vec![];
+    let mut guards = VecDeque::new();
 
     let attributes = [
         KeyValue::new("service.name", config.telemetry.service_name.to_string()),
@@ -28,10 +30,10 @@ pub fn init(config: &MoatConfig) -> Result<Box<dyn Send + Sync + 'static>> {
     ];
 
     let guard = logging::init(&config.telemetry, &config.peer, &attributes)?;
-    guards.push(guard);
+    guards.push_back(guard);
 
     let guard = meter::init(&config.telemetry, &config.peer, &attributes)?;
-    guards.push(guard);
+    guards.push_front(guard);
 
     Ok(Box::new(guards))
 }


### PR DESCRIPTION
AS IS

Now, Grafana can correctly show "No Data" after a cache node shutdown.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3dd50332-dfc2-4e74-bf0d-9ab4134ed151" />
